### PR TITLE
always use an ipv4 address

### DIFF
--- a/src/bin/stun_sans_io.rs
+++ b/src/bin/stun_sans_io.rs
@@ -9,7 +9,7 @@ fn main() -> anyhow::Result<()> {
     let socket = UdpSocket::bind("0.0.0.0:0")?;
     let server = "stun.cloudflare.com:3478"
         .to_socket_addrs()?
-        .next()
+        .find(|addr| addr.is_ipv4())
         .context("Failed to resolve hostname")?;
     let mut binding = StunBinding::new(server);
 

--- a/src/bin/stun_sans_io_time.rs
+++ b/src/bin/stun_sans_io_time.rs
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
     let socket = UdpSocket::bind("0.0.0.0:0").await?;
     let server = "stun.cloudflare.com:3478"
         .to_socket_addrs()?
-        .next()
+        .find(|addr| addr.is_ipv4())
         .context("Failed to resolve hostname")?;
     let mut binding = StunBinding::new(server);
     let mut timer = Timer::default();


### PR DESCRIPTION
The example failed for me when the first address returned by `to_socket_addrs` was an ipv6 address.